### PR TITLE
Add sample xUnit tests

### DIFF
--- a/backend/FoodCreator.sln
+++ b/backend/FoodCreator.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoodCreator", "FoodCreator.csproj", "{CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FoodCreator.Tests", "Tests/FoodCreator.Tests.csproj", "{931A0ABE-AA1A-4547-9446-EF348DBA8DA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,8 +15,12 @@ Global
 		{CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {CA10C28F-2C5E-9A82-8E90-5B718B0A3ACE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {931A0ABE-AA1A-4547-9446-EF348DBA8DA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {931A0ABE-AA1A-4547-9446-EF348DBA8DA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {931A0ABE-AA1A-4547-9446-EF348DBA8DA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {931A0ABE-AA1A-4547-9446-EF348DBA8DA7}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/backend/Tests/DishesControllerTests.cs
+++ b/backend/Tests/DishesControllerTests.cs
@@ -1,0 +1,59 @@
+using Food_Creator;
+using Food_Creator.controller;
+using Food_Creator.Model;
+using Food_Creator.Model.dto;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public class DishesControllerTests
+{
+    private ApplicationDbContext GetDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public async Task GetDishes_ReturnsAllDishes()
+    {
+        var context = GetDbContext(nameof(GetDishes_ReturnsAllDishes));
+        context.Dishes.Add(new Dish { DishId = 1, Name = "Pizza", Price = 10 });
+        await context.SaveChangesAsync();
+        var controller = new DishesController(context);
+
+        var actionResult = await controller.GetDishes();
+
+        var ok = Assert.IsType<OkObjectResult>(actionResult);
+        var result = Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task CreateDish_InvalidIngredient_ReturnsError()
+    {
+        var context = GetDbContext(nameof(CreateDish_InvalidIngredient_ReturnsError));
+        var controller = new DishesController(context);
+        var dto = new DishDto
+        {
+            Name = "Burger",
+            Price = 5,
+            DishIngredients = new List<DishIngredientDto>
+            {
+                new DishIngredientDto { IngredientId = 999, Quantity = 1 }
+            }
+        };
+
+        var result = await controller.CreateDish(dto);
+
+        var status = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, status.StatusCode);
+    }
+}

--- a/backend/Tests/FoodCreator.Tests.csproj
+++ b/backend/Tests/FoodCreator.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FoodCreator.csproj" />
+  </ItemGroup>
+</Project>

--- a/backend/Tests/IngredientsControllerTests.cs
+++ b/backend/Tests/IngredientsControllerTests.cs
@@ -1,0 +1,69 @@
+using Food_Creator;
+using Food_Creator.controller;
+using Food_Creator.Model;
+using Food_Creator.Model.dto;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public class IngredientsControllerTests
+{
+    private ApplicationDbContext GetDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public async Task GetIngredients_ReturnsAllIngredients()
+    {
+        // Arrange
+        var context = GetDbContext(nameof(GetIngredients_ReturnsAllIngredients));
+        context.Ingredients.Add(new Ingredient { IngredientId = 1, Name = "Sugar", Price = 1.1f });
+        context.Ingredients.Add(new Ingredient { IngredientId = 2, Name = "Salt", Price = 0.3f });
+        await context.SaveChangesAsync();
+        var controller = new IngredientsController(context);
+
+        // Act
+        var result = await controller.GetIngredients();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var ingredients = Assert.IsAssignableFrom<IEnumerable<IngredientDto>>(okResult.Value);
+        Assert.Equal(2, ingredients.Count());
+    }
+
+    [Fact]
+    public async Task DeleteIngredient_NotExisting_ReturnsNotFound()
+    {
+        var context = GetDbContext(nameof(DeleteIngredient_NotExisting_ReturnsNotFound));
+        var controller = new IngredientsController(context);
+
+        var result = await controller.DeleteIngredient("Unknown");
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task CreateIngredient_ValidData_AddsIngredient()
+    {
+        var context = GetDbContext(nameof(CreateIngredient_ValidData_AddsIngredient));
+        var controller = new IngredientsController(context);
+        var dto = new IngredientDto { Name = "Flour", Price = 2.5f };
+
+        var result = await controller.CreateIngredient(dto);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var ingredient = Assert.IsType<Ingredient>(created.Value);
+        Assert.Equal("Flour", ingredient.Name);
+        Assert.Single(context.Ingredients);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project for backend
- add example controller tests using EF Core in-memory DB
- register test project in backend solution

## Testing
- `dotnet test backend/FoodCreator.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685565edd008832c90f75592a11a64e2